### PR TITLE
Limit averages result display to two decimals (toFixed)

### DIFF
--- a/src/fetch/marks.js
+++ b/src/fetch/marks.js
@@ -14,10 +14,10 @@ async function marks(session, period = null)
     }
 
     if (marks.studentAverage) {
-        result.averages.student = marks.studentAverage / marks.studentAverageScale * 20;
+        result.averages.student = Number((marks.studentAverage / marks.studentAverageScale * 20).toFixed(2));
     }
     if (marks.studentClassAverage) {
-        result.averages.studentClass = marks.studentClassAverage;
+        result.averages.studentClass = Number(marks.studentClassAverage.toFixed(2));
     }
 
     for (const subject of marks.subjects.sort((a, b) => a.order - b.order)) {


### PR DESCRIPTION
Je vous propose un petit Fix.
les `averages` donnent beaucoup de decimals de mon côté.
Je vous propose de normaliser les résultats avec uniquement 2 décimals

Pour le moment, je n'ai pas ce souci avec les moyennes côté `subjects`... c'est peut-etre patché côté serveur pronote ?

@bugsounet