### PR TITLE
Ajout du nouveau label "Cours à la maison"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -632,6 +632,11 @@ export interface Lesson
     hasDuplicate: boolean,
 
     /**
+     * Si c'est un cours qui se déroulera en distanciel, à la maison.
+     */
+    remoteLesson: boolean;
+
+    /**
      * Matière du cours si disponible (pas le cas pour une retenue)
      * Peut avoir comme valeur 'Non défini' si l'api reçoit un null
      */
@@ -1755,6 +1760,7 @@ export interface PronoteLesson extends PronoteObject
     hasHomework: boolean, // AvecTafPublie
     isCancelled: boolean, // estAnnule
     isDetention: boolean // estRetenue
+    remoteLesson: boolean; // dispenseEleve.maison
 }
 
 export interface PronoteTimetableDaysAndWeeks

--- a/src/fetch/pronote/timetable.js
+++ b/src/fetch/pronote/timetable.js
@@ -38,7 +38,7 @@ async function getTimetable(session, user, week)
         hasCancelledLessons: timetable.avecCoursAnnule,
         iCalURL,
         lessons: timetable.ListeCours.map(o => fromPronote(o, ({
-            place, duree, DateDuCours, CouleurFond, ListeContenus, AvecTafPublie, Statut, estAnnule, estRetenue
+            place, duree, DateDuCours, CouleurFond, ListeContenus, AvecTafPublie, Statut, estAnnule, estRetenue, dispenseEleve
         }) => ({
             position: place,
             duration: duree,
@@ -48,7 +48,8 @@ async function getTimetable(session, user, week)
             content: parse(ListeContenus),
             hasHomework: AvecTafPublie,
             isCancelled: !!estAnnule,
-            isDetention: !!estRetenue
+            isDetention: !!estRetenue,
+            remoteLesson: !!dispenseEleve && dispenseEleve.V.maison
         }))),
         // I was unable to witness a filled "absences.joursCycle", so didn't include it
         breaks: parse(timetable.recreations, ({ place }) => ({

--- a/src/fetch/pronote/timetable.js
+++ b/src/fetch/pronote/timetable.js
@@ -38,7 +38,8 @@ async function getTimetable(session, user, week)
         hasCancelledLessons: timetable.avecCoursAnnule,
         iCalURL,
         lessons: timetable.ListeCours.map(o => fromPronote(o, ({
-            place, duree, DateDuCours, CouleurFond, ListeContenus, AvecTafPublie, Statut, estAnnule, estRetenue, dispenseEleve
+            place, duree, DateDuCours, CouleurFond, ListeContenus, AvecTafPublie, Statut, estAnnule, estRetenue,
+            dispenseEleve
         }) => ({
             position: place,
             duration: duree,

--- a/src/fetch/timetable.js
+++ b/src/fetch/timetable.js
@@ -54,6 +54,7 @@ function getTimetableWeek(session, table) {
             from,
             to,
             isDetention: lesson.isDetention,
+            remoteLesson: lesson.remoteLesson,
             status: lesson.status,
             hasDuplicate: !!table.lessons.find(l => l.date.getTime() === from.getTime() && l !== lesson)
         };

--- a/src/server/schemas/common.graphql
+++ b/src/server/schemas/common.graphql
@@ -30,6 +30,7 @@ type Lesson {
     isAway: Boolean
     isCancelled: Boolean
     color: String
+    remoteLesson: Boolean
 }
 
 type Marks {


### PR DESCRIPTION
Pronote ont récemment ajouté le label `A la maison` pour indiquer si le cours se déroule en distanciel ou en présentiel.

![Capture d’écran 2020-11-08 à 14 05 01](https://user-images.githubusercontent.com/42497995/98465769-96fa5d00-21cb-11eb-9a1f-ddd803a2c87b.png)

`remoteLesson` me semblait le plus adapté, l'équivalent de coursDistanciel en français