### PR TITLE
Vérifier si l'utilisateur a accès au serveur Pronote demandé

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -31,6 +31,9 @@ async function login(url, username, password, cas, account)
     })
 
     session.params = await getParams(session);
+    if (!session.params) {
+        throw errors.WRONG_CREDENTIALS.drop();
+    }
     if (cas === 'none') {
         await auth(session, username, password, false);
     } else {

--- a/src/fetch/pronote/params.js
+++ b/src/fetch/pronote/params.js
@@ -12,6 +12,9 @@ async function getParams(session)
     });
 
     const general = params.General;
+    if (!general) {
+        return;
+    }
     return {
         navigatorId: params.identifiantNav,
         fonts: parse(params.listePolices, false).map(o => o.L),


### PR DESCRIPTION
Bonjour,

J'ai parfois le problème suivant avec un de mes projets : l'utilisateur rentre une URL pronote, et des identifiants valides pour un certain CAS (le cas ac-toulouse par exemple).  L'authentification se passe donc correctement, l'utilisateur est bien connecté au CAS... mais n'a en fait pas accès au serveur Pronote demandé. Ça vous est peut-être arrivé on tombe sur une page comme ça : 
![Capture d’écran 2020-12-07 à 18 41 47](https://user-images.githubusercontent.com/42497995/101385324-f081a480-38bb-11eb-88a1-98d014fc67f4.png)
Ce fix fait juste en sorte de renvoyer une erreur "mauvais identifiant" si ça arrive (au lieu d'afficher une erreur `Cannot read property 'urlSiteIndexEducation' of undefined`).