### PR TITLE
fix: update atrium sud url for getCas()

### DIFF
--- a/src/cas/find.js
+++ b/src/cas/find.js
@@ -24,7 +24,7 @@ const URLS = {
     'ac-valdoise': 'cas.moncollege.valdoise.fr',
     'agora06': 'cas.agora06.fr',
     'arsene76': 'cas.arsene76.fr',
-    'atrium-sud': 'atrium-sud.fr',
+    'atrium-sud': 'www.atrium-sud.fr',
     'cybercolleges42': 'cas.cybercolleges42.fr',
     'eure-normandie': 'cas.ent27.fr',
     'haute-garonne': 'cas.ecollege.haute-garonne.fr',


### PR DESCRIPTION
```js
pronote.getCAS('https://0061760f.index-education.net/pronote/').then((cas) => console.log(cas));
// renvoie null au lieu du cas atrium-sud
```