### PR TITLE
fix: convert empty object to empty array

### DIFF
--- a/src/geo.js
+++ b/src/geo.js
@@ -24,7 +24,8 @@ function geo(lat, long) {
                 incomingData += data;
             });
             res.on('end', () => {
-                resolve(JSON.parse(incomingData));
+                const data = JSON.parse(incomingData);
+                resolve(Array.isArray(data) ? data : []);
             });
         });
 


### PR DESCRIPTION
When we use a location without any establishments, instead of returning an empty array, it returns... an empty object. It's pretty weird, you can try:
```js
// toulouse
pronote.geo('43', '1');
/*
[ EstablishmentObject, EstablishmentObject, ... ]
*/

// new york
pronote.geo('37', '122');
/*
{}
*/

instead of something like []